### PR TITLE
Add SDF Viewer as another renderer for this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 A rewrite of the original CAD package [`sdfx`](https://github.com/deadsy/sdfx) for generating 2D and 3D geometry using [Go](https://go.dev/).
 
 ## Highlights
-* GUI with real-time rendering using [sdf3ui](https://github.com/soypat/sdf3ui).
+* GUI with real-time rendering using [sdf3ui](https://github.com/soypat/sdf3ui) (or [SDF Viewer](https://github.com/Yeicor/sdf-viewer-go)).
 * 3d and 2d objects modelled with signed distance functions (SDFs).
 * Minimal and idiomatic API.
 * Render objects as triangles or save to STL, 3MF(experimental) file format.


### PR DESCRIPTION
I made a real-time, cross-platform, language-agnostic SDF Viewer application, and integrated it with your SDF library. It works similarly to `sdf3ui` but has some extra features (AFAIK):

- Different rendering algorithm that allows observing the model preview while it is being loaded.
- Shows the hierarchy of SDFs that build the final model and can render any subtree.
- Support for textures and material properties (and even exporting them).
- Support for customizing parameters in real-time from the UI without modifying the code (useful for publishing, it also listens for code changes and refreshes the view)
- You can publish your SDF by uploading a file to a server and sharing the renderer link (renders and allows to customize and generate a mesh of the SDF in the browser without any backend).
- More meshing algorithms running on all platforms (although speed is not a concern).

Check out https://github.com/Yeicor/sdf-viewer and https://github.com/Yeicor/sdf-viewer-go for much more information.

A little demo:

https://user-images.githubusercontent.com/4929005/187038442-0f209197-85ed-4dc1-b2aa-a0ba54da43ff.mp4

Note that I had to use TinyGo instead of the Go Compiler, so the builds (after the code change) are a lot slower than Go.

Another useful feature is verifying that the SDF is properly defined, as a bad SDF will show artifacts on the SDF renderer (even if marching cubes or other algorithms seem to return a valid result). For example, it seems like `ScaleUniform3D` may not be correct (I haven't looked at it, it may also be an error with the integration), as it gives some render issues:

- Without `ScaleUniform3D`:
![Screenshot_20220827_175604](https://user-images.githubusercontent.com/4929005/187037969-c5a5bf72-51b8-4aea-b209-74007df520db.png)

- With `ScaleUniform3D`:
![Screenshot_20220827_175647](https://user-images.githubusercontent.com/4929005/187037991-b9f95fe7-7359-43b0-baf7-9cc5e6b6e9c5.png)

